### PR TITLE
[HW] Clean-up Ara on Cheshire

### DIFF
--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -274,6 +274,7 @@ package ara_pkg;
     logic use_vs1;
     opqueue_conversion_e conversion_vs1;
     rvv_pkg::vew_e eew_vs1;
+    rvv_pkg::vew_e old_eew_vs1;
 
     // 2nd vector register operand
     logic [4:0] vs2;
@@ -378,6 +379,7 @@ package ara_pkg;
     logic use_vs1;
     opqueue_conversion_e conversion_vs1;
     rvv_pkg::vew_e eew_vs1;
+    rvv_pkg::vew_e old_eew_vs1;
 
     // 2nd vector register operand
     logic [4:0] vs2;

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -27,6 +27,8 @@ package ara_pkg;
   // Number of vector instructions that can run in parallel.
   localparam int unsigned NrVInsn = 8;
 
+  // Number of bits in a vector register.
+  localparam int unsigned NrLanes  = `ifdef NR_LANES `NR_LANES `else 0 `endif;
   // Maximum number of lanes that Ara can support.
   localparam int unsigned MaxNrLanes = 16;
 
@@ -365,6 +367,11 @@ package ara_pkg;
 
     // Rescale vl taking into account the new and old EEW
     logic scale_vl;
+
+    // The lane that provides the first element of the computation
+    logic [$clog2(NrLanes)-1:0] start_lane;
+    // The lane that provides the last element of the computation
+    logic [$clog2(NrLanes)-1:0] end_lane;
 
     // 1st vector register operand
     logic [4:0] vs1;
@@ -982,11 +989,11 @@ package ara_pkg;
     // Each vector register spans multiple words in each bank in each lane
     // The start address is the same in every lane
     // Therefore, within each lane, each vector register chunk starts on a given offset
-    vaddr = vid * (VLENB / NrLanes / NrVRFBanksPerLane); 
+    vaddr = vid * (VLENB / NrLanes / NrVRFBanksPerLane);
     // NOTE: the only extensively tested configuration of Ara keeps:
     //        - (VLEN / NrLanes) constant to 1024;
     //        - NrVRFBanksPerLane always equal to 8.
-    //        Given so, each vector register will span 2 words across all the banks and lanes, 
+    //        Given so, each vector register will span 2 words across all the banks and lanes,
     //        therefore, vaddr = vid * 16
   endfunction: vaddr
 

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -2053,4 +2053,14 @@ package ara_pkg;
     return vfrsqrt7_o;
   endfunction : vfrsqrt7_fp64
 
+  ////////////////
+  // Exceptions //
+  ////////////////
+
+  // End-to-end store exception latency, i.e.,
+  // the latency from the addrgen store exception to the opqueues.
+  // We keep it as a define to implement conditional declaration.
+  `define StuExLat 1
+  localparam int unsigned StuExLat = `StuExLat;
+
 endpackage : ara_pkg

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -1017,6 +1017,7 @@ package ara_pkg;
     resize_e cvt_resize;    // Resizing of FP conversions
 
     logic is_reduct; // Is this a reduction?
+    logic is_slide; // Is this a slide?
 
     rvv_pkg::vew_e eew;        // Effective element width
     opqueue_conversion_e conv; // Type conversion
@@ -1026,7 +1027,7 @@ package ara_pkg;
     // Vector machine metadata
     rvv_pkg::vtype_t vtype;
     vlen_t vl;
-    vlen_t vstart;
+    vlen_t vstart; // In the lanes, this is NOT the architectural vstart
 
     // Hazards
     logic [NrVInsn-1:0] hazard;

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -1121,6 +1121,7 @@ package ara_pkg;
     axi_pkg::size_t size;
     axi_pkg::len_t len;
     logic is_load;
+    logic is_exception;
   } addrgen_axi_req_t;
 
 

--- a/hardware/src/ara.sv
+++ b/hardware/src/ara.sv
@@ -140,7 +140,6 @@ module ara import ara_pkg::*; #(
   logic              [NrPEs-1:0]   pe_req_ready;
   logic              [NrVInsn-1:0] pe_vinsn_running;
   pe_resp_t          [NrPEs-1:0]   pe_resp;
-  logic              [NrLanes-1:0] need_mock_operand;
   // Interface with the address generator
   logic                            addrgen_ack;
   ariane_pkg::exception_t          addrgen_exception;
@@ -183,7 +182,6 @@ module ara import ara_pkg::*; #(
     .pe_resp_i             (pe_resp                  ),
     .alu_vinsn_done_i      (alu_vinsn_done[0]        ),
     .mfpu_vinsn_done_i     (mfpu_vinsn_done[0]       ),
-    .need_mock_operand_o   (need_mock_operand        ),
     // Interface with the operand requesters
     .global_hazard_table_o (global_hazard_table      ),
     // Interface with the lane 0
@@ -275,7 +273,6 @@ module ara import ara_pkg::*; #(
       .alu_vinsn_done_o                (alu_vinsn_done[lane]                ),
       .mfpu_vinsn_done_o               (mfpu_vinsn_done[lane]               ),
       .global_hazard_table_i           (global_hazard_table                 ),
-      .need_mock_operand_i             (need_mock_operand[lane]             ),
       // Interface with the slide unit
       .sldu_result_req_i               (sldu_result_req[lane]               ),
       .sldu_result_addr_i              (sldu_result_addr[lane]              ),

--- a/hardware/src/ara.sv
+++ b/hardware/src/ara.sv
@@ -37,10 +37,10 @@ module ara import ara_pkg::*; #(
     input  logic              scan_enable_i,
     input  logic              scan_data_i,
     output logic              scan_data_o,
-    
+
     // CSR input
     input  logic              en_ld_st_translation_i,
-    
+
     // Interface with CVA6's sv39 MMU
     // This is everything the MMU can provide, it might be overcomplete for Ara and some signals be useless
     output  ariane_pkg::exception_t        mmu_misaligned_ex_o,
@@ -140,6 +140,7 @@ module ara import ara_pkg::*; #(
   logic              [NrPEs-1:0]   pe_req_ready;
   logic              [NrVInsn-1:0] pe_vinsn_running;
   pe_resp_t          [NrPEs-1:0]   pe_resp;
+  logic              [NrLanes-1:0] need_mock_operand;
   // Interface with the address generator
   logic                            addrgen_ack;
   ariane_pkg::exception_t          addrgen_exception;
@@ -182,6 +183,7 @@ module ara import ara_pkg::*; #(
     .pe_resp_i             (pe_resp                  ),
     .alu_vinsn_done_i      (alu_vinsn_done[0]        ),
     .mfpu_vinsn_done_i     (mfpu_vinsn_done[0]       ),
+    .need_mock_operand_o   (need_mock_operand        ),
     // Interface with the operand requesters
     .global_hazard_table_o (global_hazard_table      ),
     // Interface with the lane 0
@@ -273,6 +275,7 @@ module ara import ara_pkg::*; #(
       .alu_vinsn_done_o                (alu_vinsn_done[lane]                ),
       .mfpu_vinsn_done_o               (mfpu_vinsn_done[lane]               ),
       .global_hazard_table_i           (global_hazard_table                 ),
+      .need_mock_operand_i             (need_mock_operand[lane]             ),
       // Interface with the slide unit
       .sldu_result_req_i               (sldu_result_req[lane]               ),
       .sldu_result_addr_i              (sldu_result_addr[lane]              ),
@@ -376,7 +379,7 @@ module ara import ara_pkg::*; #(
     .addrgen_operand_target_fu_i(sldu_addrgen_operand_target_fu                        ),
     .addrgen_operand_valid_i    (sldu_addrgen_operand_valid                            ),
     .addrgen_operand_ready_o    (addrgen_operand_ready                                 ),
-    // CSR input    
+    // CSR input
     .en_ld_st_translation_i,
     // Interface with CVA6's sv39 MMU
     .mmu_misaligned_ex_o   ,

--- a/hardware/src/ara.sv
+++ b/hardware/src/ara.sv
@@ -210,7 +210,7 @@ module ara import ara_pkg::*; #(
   elen_t     [NrLanes-1:0]                     stu_operand;
   logic      [NrLanes-1:0]                     stu_operand_valid;
   logic      [NrLanes-1:0]                     stu_operand_ready;
-  logic                                        stu_exception;
+  logic                                        stu_exception_flush;
   // Slide unit/address generation operands
   elen_t     [NrLanes-1:0]                     sldu_addrgen_operand;
   target_fu_e[NrLanes-1:0]                     sldu_addrgen_operand_target_fu;
@@ -293,7 +293,7 @@ module ara import ara_pkg::*; #(
       .stu_operand_o                   (stu_operand[lane]                   ),
       .stu_operand_valid_o             (stu_operand_valid[lane]             ),
       .stu_operand_ready_i             (stu_operand_ready[lane]             ),
-      .stu_exception_i                 ( stu_exception                      ), // Broadcast to all lanes
+      .stu_exception_flush_i           (stu_exception_flush                 ),
       // Interface with the slide/address generation unit
       .sldu_addrgen_operand_o          (sldu_addrgen_operand[lane]          ),
       .sldu_addrgen_operand_target_fu_o(sldu_addrgen_operand_target_fu[lane]),
@@ -370,7 +370,7 @@ module ara import ara_pkg::*; #(
     .stu_operand_i              (stu_operand                                           ),
     .stu_operand_valid_i        (stu_operand_valid                                     ),
     .stu_operand_ready_o        (stu_operand_ready                                     ),
-    .stu_exception_o            ( stu_exception                                        ),
+    .stu_exception_flush_o      (stu_exception_flush                                   ),
     // Address Generation
     .addrgen_operand_i          (sldu_addrgen_operand                                  ),
     .addrgen_operand_target_fu_i(sldu_addrgen_operand_target_fu                        ),

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -341,6 +341,9 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
         rs_lmul_cnt_limit_d = rs_lmul_cnt_limit_q;
         rs_mask_request_d   = 1'b0;
 
+        // Every single reshuffle request refers to LMUL == 1
+        ara_req_d.emul = LMUL_1;
+
         // vstart is always 0 for a reshuffle
         ara_req_d.vstart = '0;
 

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -2875,9 +2875,11 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
               acc_resp_o.resp_valid = 1'b1;
               acc_resp_o.exception  = ara_resp_i.exception;
               ara_req_valid_d       = 1'b0; // Clear request to backend
-              // In case of exception, modify vstart
+              // In case of exception, modify vstart and wait until the previous
+              // operations are over
               if ( ara_resp_i.exception.valid ) begin : exception
                 csr_vstart_d = ara_resp_i.exception_vstart;
+                state_d = WAIT_IDLE;
               end : exception
             end : ara_resp_valid
 

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -141,6 +141,9 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
   // We need to memorize the element width used to store each vector on the lanes, so that we are
   // able to deshuffle it when needed.
   rvv_pkg::vew_e [31:0] eew_d, eew_q;
+  // eew buffers for reshuffling
+  rvv_pkg::vew_e reshuffle_eew_vs1_d, reshuffle_eew_vs1_q;
+  rvv_pkg::vew_e reshuffle_eew_vs2_d, reshuffle_eew_vs2_q;
   // If the reg was not written, the content is unknown. No need to reshuffle
   // when writing with != EEW
   logic [31:0] eew_valid_d, eew_valid_q;
@@ -167,6 +170,8 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
       rs_lmul_cnt_q       <= '0;
       rs_lmul_cnt_limit_q <= '0;
       rs_mask_request_q   <= 1'b0;
+      reshuffle_eew_vs1_q <= rvv_pkg::EW8;
+      reshuffle_eew_vs2_q <= rvv_pkg::EW8;
     end else begin
       state_q             <= state_d;
       eew_q               <= eew_d;
@@ -178,6 +183,8 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
       rs_lmul_cnt_q       <= rs_lmul_cnt_d;
       rs_lmul_cnt_limit_q <= rs_lmul_cnt_limit_d;
       rs_mask_request_q   <= rs_mask_request_d;
+      reshuffle_eew_vs1_q <= reshuffle_eew_vs1_d;
+      reshuffle_eew_vs2_q <= reshuffle_eew_vs2_d;
     end
   end
 
@@ -246,10 +253,12 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
     lmul_vs2     = csr_vtype_q.vlmul;
     lmul_vs1     = csr_vtype_q.vlmul;
 
-    reshuffle_req_d  = reshuffle_req_q;
-    eew_old_buffer_d = eew_old_buffer_q;
-    eew_new_buffer_d = eew_new_buffer_q;
-    vs_buffer_d      = vs_buffer_q;
+    reshuffle_req_d     = reshuffle_req_q;
+    eew_old_buffer_d    = eew_old_buffer_q;
+    eew_new_buffer_d    = eew_new_buffer_q;
+    vs_buffer_d         = vs_buffer_q;
+    reshuffle_eew_vs1_d = reshuffle_eew_vs1_q;
+    reshuffle_eew_vs2_d = reshuffle_eew_vs2_q;
 
     rs_lmul_cnt_d       = '0;
     rs_lmul_cnt_limit_d = '0;
@@ -375,19 +384,14 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
             // Prepare the information to reshuffle the vector registers during the next cycles
             // Reshuffle in the following order: vd, v2, v1. The order is arbitrary.
             unique casez (reshuffle_req_d)
-              3'b??1: begin
-                eew_old_buffer_d = eew_q[insn.vmem_type.rd];
-                eew_new_buffer_d = ara_req_d.vtype.vsew;
-                vs_buffer_d      = insn.varith_type.rd;
-              end
               3'b?10: begin
                 eew_old_buffer_d = eew_q[insn.vmem_type.rs2];
-                eew_new_buffer_d = ara_req_d.eew_vs2;
+                eew_new_buffer_d = reshuffle_eew_vs2_q;
                 vs_buffer_d      = insn.varith_type.rs2;
               end
               3'b100: begin
                 eew_old_buffer_d = eew_q[insn.vmem_type.rs1];
-                eew_new_buffer_d = ara_req_d.eew_vs1;
+                eew_new_buffer_d = reshuffle_eew_vs1_q;
                 vs_buffer_d      = insn.varith_type.rs1;
               end
               default:;
@@ -3158,6 +3162,11 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
         reshuffle_req_d = {ara_req_d.use_vs1 && (ara_req_d.eew_vs1    != eew_q[ara_req_d.vs1]) && eew_valid_q[ara_req_d.vs1] && in_lane_op,
                            ara_req_d.use_vs2 && (ara_req_d.eew_vs2    != eew_q[ara_req_d.vs2]) && eew_valid_q[ara_req_d.vs2] && in_lane_op,
                            ara_req_d.use_vd  && (ara_req_d.vtype.vsew != eew_q[ara_req_d.vd ]) && eew_valid_q[ara_req_d.vd ] && csr_vl_q != (VLENB >> ara_req_d.vtype.vsew)};
+        // Mask out requests if they refer to the same register!
+        reshuffle_req_d &= {
+          (insn.varith_type.rs1 != insn.varith_type.rs2) && (insn.varith_type.rs1 != insn.varith_type.rd),
+          (insn.varith_type.rs2 != insn.varith_type.rd),
+          1'b1};
 
         // Prepare the information to reshuffle the vector registers during the next cycles
         // Reshuffle in the following order: vd, v2, v1. The order is arbitrary.
@@ -3198,6 +3207,10 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
           LMUL_8:  rs_lmul_cnt_limit_d = 7;
           default: rs_lmul_cnt_limit_d = 0;
         endcase
+
+        // Save info for next reshuffles
+        reshuffle_eew_vs1_d = ara_req_d.eew_vs1;
+        reshuffle_eew_vs2_d = ara_req_d.eew_vs2;
 
         // Reshuffle
         state_d = RESHUFFLE;

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -2713,7 +2713,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
             // These generate a request to Ara's backend
             ara_req_d.vs1       = insn.vmem_type.rd; // vs3 is encoded in the same position as rd
             ara_req_d.use_vs1   = 1'b1;
-            ara_req_d.eew_vs1   = eew_q[insn.vmem_type.rd]; // This is the vs1 EEW
+            ara_req_d.old_eew_vs1 = eew_q[insn.vmem_type.rd]; // This is the old vs1 EEW;
             ara_req_d.vm        = insn.vmem_type.vm;
             ara_req_d.scalar_op = acc_req_i.rs1;
             ara_req_valid_d     = 1'b1;
@@ -2880,6 +2880,8 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                 csr_vstart_d = ara_resp_i.exception_vstart;
               end : exception
             end : ara_resp_valid
+
+            ara_req_d.eew_vs1 = ara_req_d.vtype.vsew; // This is the new vs1 EEW
           end : OpcodeStoreFp
 
           ////////////////////////////
@@ -3159,7 +3161,8 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
         // Annotate which registers need a reshuffle -> |vs1|vs2|vd|
         // Optimization: reshuffle vs1 and vs2 only if the operation is strictly in-lane
         // Optimization: reshuffle vd only if we are not overwriting the whole vector register!
-        reshuffle_req_d = {ara_req_d.use_vs1 && (ara_req_d.eew_vs1    != eew_q[ara_req_d.vs1]) && eew_valid_q[ara_req_d.vs1] && in_lane_op,
+        // During a vstore, if vstart > 0, reshuffle immediately not to complicate operand fetch stage
+        reshuffle_req_d = {ara_req_d.use_vs1 && (ara_req_d.eew_vs1    != eew_q[ara_req_d.vs1]) && eew_valid_q[ara_req_d.vs1] && (in_lane_op || (is_vstore && (csr_vstart_q != '0))),
                            ara_req_d.use_vs2 && (ara_req_d.eew_vs2    != eew_q[ara_req_d.vs2]) && eew_valid_q[ara_req_d.vs2] && in_lane_op,
                            ara_req_d.use_vd  && (ara_req_d.vtype.vsew != eew_q[ara_req_d.vd ]) && eew_valid_q[ara_req_d.vd ] && csr_vl_q != (VLENB >> ara_req_d.vtype.vsew)};
         // Mask out requests if they refer to the same register!
@@ -3182,9 +3185,9 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
             vs_buffer_d      = insn.varith_type.rs2;
           end
           3'b100: begin
-            eew_old_buffer_d = eew_q[insn.vmem_type.rs1];
+            eew_old_buffer_d = is_vstore ? eew_q[insn.vmem_type.rd] : eew_q[insn.vmem_type.rs1];
             eew_new_buffer_d = ara_req_d.eew_vs1;
-            vs_buffer_d      = insn.varith_type.rs1;
+            vs_buffer_d      = is_vstore ? insn.vmem_type.rd : insn.varith_type.rs1;
           end
           default:;
         endcase

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -144,6 +144,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
   // eew buffers for reshuffling
   rvv_pkg::vew_e reshuffle_eew_vs1_d, reshuffle_eew_vs1_q;
   rvv_pkg::vew_e reshuffle_eew_vs2_d, reshuffle_eew_vs2_q;
+  rvv_pkg::vew_e reshuffle_eew_vd_d, reshuffle_eew_vd_q;
   // If the reg was not written, the content is unknown. No need to reshuffle
   // when writing with != EEW
   logic [31:0] eew_valid_d, eew_valid_q;
@@ -172,6 +173,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
       rs_mask_request_q   <= 1'b0;
       reshuffle_eew_vs1_q <= rvv_pkg::EW8;
       reshuffle_eew_vs2_q <= rvv_pkg::EW8;
+      reshuffle_eew_vd_q  <= rvv_pkg::EW8;
     end else begin
       state_q             <= state_d;
       eew_q               <= eew_d;
@@ -185,6 +187,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
       rs_mask_request_q   <= rs_mask_request_d;
       reshuffle_eew_vs1_q <= reshuffle_eew_vs1_d;
       reshuffle_eew_vs2_q <= reshuffle_eew_vs2_d;
+      reshuffle_eew_vd_q  <= reshuffle_eew_vd_d;
     end
   end
 
@@ -259,6 +262,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
     vs_buffer_d         = vs_buffer_q;
     reshuffle_eew_vs1_d = reshuffle_eew_vs1_q;
     reshuffle_eew_vs2_d = reshuffle_eew_vs2_q;
+    reshuffle_eew_vd_d  = reshuffle_eew_vd_q;
 
     rs_lmul_cnt_d       = '0;
     rs_lmul_cnt_limit_d = '0;
@@ -386,6 +390,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
 
             // Prepare the information to reshuffle the vector registers during the next cycles
             // Reshuffle in the following order: vd, v2, v1. The order is arbitrary.
+            // If we are here, vd has been already reshuffled.
             unique casez (reshuffle_req_d)
               3'b?10: begin
                 eew_old_buffer_d = eew_q[insn.vmem_type.rs2];
@@ -426,17 +431,17 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
               3'b??1: begin
                 vs_buffer_d      = vs_buffer_q + 1;
                 eew_old_buffer_d = eew_q[vs_buffer_d];
-                eew_new_buffer_d = ara_req_d.vtype.vsew;
+                eew_new_buffer_d = reshuffle_eew_vd_q;
               end
               3'b?10: begin
                 vs_buffer_d      = vs_buffer_q + 1;
                 eew_old_buffer_d = eew_q[vs_buffer_d];
-                eew_new_buffer_d = ara_req_d.eew_vs2;
+                eew_new_buffer_d = reshuffle_eew_vs2_q;
               end
               3'b100: begin
                 vs_buffer_d      = vs_buffer_q + 1;
                 eew_old_buffer_d = eew_q[vs_buffer_d];
-                eew_new_buffer_d = ara_req_d.eew_vs1;
+                eew_new_buffer_d = reshuffle_eew_vs1_q;
               end
               default:;
             endcase
@@ -3232,6 +3237,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
         // Save info for next reshuffles
         reshuffle_eew_vs1_d = ara_req_d.eew_vs1;
         reshuffle_eew_vs2_d = ara_req_d.eew_vs2;
+        reshuffle_eew_vd_d  = ara_req_d.vtype.vsew;
 
         // Reshuffle
         state_d = RESHUFFLE;

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -3187,7 +3187,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
         // During a vstore, if vstart > 0, reshuffle immediately not to complicate operand fetch stage
         reshuffle_req_d = {ara_req_d.use_vs1 && (ara_req_d.eew_vs1    != eew_q[ara_req_d.vs1]) && eew_valid_q[ara_req_d.vs1] && (in_lane_op || (is_vstore && (csr_vstart_q != '0))),
                            ara_req_d.use_vs2 && (ara_req_d.eew_vs2    != eew_q[ara_req_d.vs2]) && eew_valid_q[ara_req_d.vs2] && in_lane_op,
-                           ara_req_d.use_vd  && (ara_req_d.vtype.vsew != eew_q[ara_req_d.vd ]) && eew_valid_q[ara_req_d.vd ] && csr_vl_q != (VLENB >> ara_req_d.vtype.vsew)};
+                           ara_req_d.use_vd  && (ara_req_d.vtype.vsew != eew_q[ara_req_d.vd ]) && eew_valid_q[ara_req_d.vd ] && csr_vl_q != ((VLENB << ara_req_d.emul[1:0]) >> ara_req_d.vtype.vsew)};
         // Mask out requests if they refer to the same register!
         reshuffle_req_d &= {
           (insn.varith_type.rs1 != insn.varith_type.rs2) && (insn.varith_type.rs1 != insn.varith_type.rd),

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -271,8 +271,8 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
 
     null_vslideup = 1'b0;
 
-    is_decoding = 1'b0;
-    in_lane_op  = 1'b0;
+    is_decoding     = 1'b0;
+    in_lane_op      = 1'b0;
 
     acc_resp_o       = '{
       trans_id      : acc_req_i.trans_id,
@@ -331,6 +331,9 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
         rs_lmul_cnt_d       = rs_lmul_cnt_q;
         rs_lmul_cnt_limit_d = rs_lmul_cnt_limit_q;
         rs_mask_request_d   = 1'b0;
+
+        // vstart is always 0 for a reshuffle
+        ara_req_d.vstart = '0;
 
         // These generate a reshuffle request to Ara's backend
         // When LMUL > 1, not all the regs that compose a large
@@ -3141,17 +3144,6 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
         acc_resp_o.exception.tval  = acc_req_i.insn;
       end : illegal_instruction
 
-      // Reset vstart to zero for successful vector instructions
-      // Corner cases:
-      // * vstart exception reporting, e.g., VLSU, is handled above
-      // * CSR operations are not considered vector instructions
-      if ( acc_resp_o.resp_valid 
-            & !acc_resp_o.exception.valid 
-            & (acc_req_i.insn.itype.opcode != riscv::OpcodeSystem)
-          ) begin : reset_vstart
-        csr_vstart_d = '0;
-      end : reset_vstart
-
       // Check if we need to reshuffle our vector registers involved in the operation
       // This operation is costly when occurs, so avoid it if possible
       if ( ara_req_valid_d && !acc_resp_o.exception.valid ) begin : check_reshuffle
@@ -3250,7 +3242,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
 
     // Any valid non-config instruction is a NOP if vl == 0, with some exceptions,
     // e.g. whole vector memory operations / whole vector register move
-    if (is_decoding && (csr_vl_q == '0 || null_vslideup) && !is_config &&
+    if (is_decoding && (csr_vstart_q >= csr_vl_q || null_vslideup) && !is_config &&
       !ignore_zero_vl_check && !acc_resp_o.exception.valid) begin
       // If we are acknowledging a memory operation, we must tell Ariane that the memory
       // operation was resolved (to decrement its pending load/store counter)
@@ -3262,6 +3254,17 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
       load_zero_vl     = is_vload;
       store_zero_vl    = is_vstore;
     end
+
+    // Reset vstart to zero for successful vector instructions
+    // Corner cases:
+    // * vstart exception reporting, e.g., VLSU, is handled above
+    // * CSR operations are not considered vector instructions
+    if ( acc_resp_o.resp_valid
+          & !acc_resp_o.exception.valid
+          & (acc_req_i.insn.itype.opcode != riscv::OpcodeSystem)
+        ) begin : reset_vstart
+      csr_vstart_d = '0;
+    end : reset_vstart
 
     acc_resp_o.load_complete  = load_zero_vl  | load_complete_q;
     acc_resp_o.store_complete = store_zero_vl | store_complete_q;

--- a/hardware/src/ara_sequencer.sv
+++ b/hardware/src/ara_sequencer.sv
@@ -150,8 +150,10 @@ module ara_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
   logic [$clog2(2*NrLanes)-1:0] buf32;
 
   always_comb begin
-    // No default values since we cover all the possible cases with default.
-    // Don't use zero to save some logic.
+    // start_lane and end_lane has default values in the unique case statement already
+    buf8       = '0;
+    buf16      = '0;
+    buf32      = '0;
 
     // Start lane
     // Number of elements in a single L*64-bit fetch: (NrLanes << (64 - pe_req_d.vtype.vsew)).

--- a/hardware/src/ara_sequencer.sv
+++ b/hardware/src/ara_sequencer.sv
@@ -413,6 +413,7 @@ module ara_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
               use_vs1       : ara_req_i.use_vs1,
               conversion_vs1: ara_req_i.conversion_vs1,
               eew_vs1       : ara_req_i.eew_vs1,
+              old_eew_vs1   : ara_req_i.old_eew_vs1,
               vs2           : ara_req_i.vs2,
               use_vs2       : ara_req_i.use_vs2,
               conversion_vs2: ara_req_i.conversion_vs2,

--- a/hardware/src/lane/lane.sv
+++ b/hardware/src/lane/lane.sv
@@ -96,6 +96,8 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     output logic                                           mask_ready_o
   );
 
+  `include "common_cells/registers.svh"
+
   /////////////////
   //  Spill Reg  //
   /////////////////
@@ -306,6 +308,10 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
   logic sldu_operand_opqueues_ready;
   logic sldu_addrgen_operand_opqueues_valid;
 
+  // Cut stu_exception path
+  logic stu_exception_q;
+  `FF(stu_exception_q, stu_exception_i, 1'b0, clk_i, rst_ni);
+
   operand_queues_stage #(
     .NrLanes   (NrLanes   ),
     .FPUSupport(FPUSupport)
@@ -334,6 +340,7 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     .stu_operand_o                    (stu_operand_o                      ),
     .stu_operand_valid_o              (stu_operand_valid_o                ),
     .stu_operand_ready_i              (stu_operand_ready_i                ),
+    .stu_exception_i                  (stu_exception_q                    ),
     // Address Generation Unit
     .sldu_addrgen_operand_o           (sldu_addrgen_operand_opqueues      ),
     .sldu_addrgen_operand_target_fu_o (sldu_addrgen_operand_target_fu_o   ),

--- a/hardware/src/lane/lane.sv
+++ b/hardware/src/lane/lane.sv
@@ -50,6 +50,7 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     output logic                                           alu_vinsn_done_o,
     output logic                                           mfpu_vinsn_done_o,
     input  logic                [NrVInsn-1:0][NrVInsn-1:0] global_hazard_table_i,
+    input  logic                                           need_mock_operand_i,
     // Interface with the Store unit
     output elen_t                                          stu_operand_o,
     output logic                                           stu_operand_valid_o,
@@ -145,6 +146,7 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     .pe_vinsn_running_i     (pe_vinsn_running_i   ),
     .pe_req_ready_o         (pe_req_ready_o       ),
     .pe_resp_o              (pe_resp_o            ),
+    .need_mock_operand_i    (need_mock_operand_i  ),
     // Interface with the operand requesters
     .operand_request_o      (operand_request      ),
     .operand_request_valid_o(operand_request_valid),

--- a/hardware/src/lane/lane.sv
+++ b/hardware/src/lane/lane.sv
@@ -50,7 +50,6 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     output logic                                           alu_vinsn_done_o,
     output logic                                           mfpu_vinsn_done_o,
     input  logic                [NrVInsn-1:0][NrVInsn-1:0] global_hazard_table_i,
-    input  logic                                           need_mock_operand_i,
     // Interface with the Store unit
     output elen_t                                          stu_operand_o,
     output logic                                           stu_operand_valid_o,
@@ -146,7 +145,6 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     .pe_vinsn_running_i     (pe_vinsn_running_i   ),
     .pe_req_ready_o         (pe_req_ready_o       ),
     .pe_resp_o              (pe_resp_o            ),
-    .need_mock_operand_i    (need_mock_operand_i  ),
     // Interface with the operand requesters
     .operand_request_o      (operand_request      ),
     .operand_request_valid_o(operand_request_valid),

--- a/hardware/src/lane/lane.sv
+++ b/hardware/src/lane/lane.sv
@@ -54,7 +54,7 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     output elen_t                                          stu_operand_o,
     output logic                                           stu_operand_valid_o,
     input  logic                                           stu_operand_ready_i,
-    input  logic                                           stu_exception_i ,
+    input  logic                                           stu_exception_flush_i,
     // Interface with the Slide/Address Generation unit
     output elen_t                                          sldu_addrgen_operand_o,
     output target_fu_e                                     sldu_addrgen_operand_target_fu_o,
@@ -259,7 +259,7 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     .ldu_result_gnt_o         (ldu_result_gnt_o        ),
     .ldu_result_final_gnt_o   (ldu_result_final_gnt_o  ),
     // Store Unit
-    .stu_exception_i          ( stu_exception_i        )
+    .stu_exception_i          ( stu_exception_flush_i  )
   );
 
   ////////////////////////////
@@ -309,13 +309,13 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
   logic sldu_addrgen_operand_opqueues_valid;
 
   // Cut stu_exception path
-  logic stu_exception;
-  logic [StuExLat:0] stu_exception_d, stu_exception_q;
-  assign stu_exception_d[0] = stu_exception_i;
-  assign stu_exception      = StuExLat == 0 ? stu_exception_i : stu_exception_q[StuExLat-1];
+  logic stu_exception_flush;
+  logic [StuExLat:0] stu_exception_flush_d, stu_exception_flush_q;
+  assign stu_exception_flush_d[0] = stu_exception_flush_i;
+  assign stu_exception_flush      = StuExLat == 0 ? stu_exception_flush_i : stu_exception_flush_q[StuExLat-1];
   for (genvar i = 0; i < StuExLat; i++) begin
-    assign stu_exception_d[i+1] = stu_exception_q[i];
-    `FF(stu_exception_q[i], stu_exception_d[i], 1'b0, clk_i, rst_ni);
+    assign stu_exception_flush_d[i+1] = stu_exception_flush_q[i];
+    `FF(stu_exception_flush_q[i], stu_exception_flush_d[i], 1'b0, clk_i, rst_ni);
   end
 
   operand_queues_stage #(
@@ -346,7 +346,7 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     .stu_operand_o                    (stu_operand_o                      ),
     .stu_operand_valid_o              (stu_operand_valid_o                ),
     .stu_operand_ready_i              (stu_operand_ready_i                ),
-    .stu_exception_i                  (stu_exception                      ),
+    .stu_exception_flush_i            (stu_exception_flush                ),
     // Address Generation Unit
     .sldu_addrgen_operand_o           (sldu_addrgen_operand_opqueues      ),
     .sldu_addrgen_operand_target_fu_o (sldu_addrgen_operand_target_fu_o   ),

--- a/hardware/src/lane/lane.sv
+++ b/hardware/src/lane/lane.sv
@@ -309,8 +309,14 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
   logic sldu_addrgen_operand_opqueues_valid;
 
   // Cut stu_exception path
-  logic stu_exception_q;
-  `FF(stu_exception_q, stu_exception_i, 1'b0, clk_i, rst_ni);
+  logic stu_exception;
+  logic [StuExLat:0] stu_exception_d, stu_exception_q;
+  assign stu_exception_d[0] = stu_exception_i;
+  assign stu_exception      = StuExLat == 0 ? stu_exception_i : stu_exception_q[StuExLat-1];
+  for (genvar i = 0; i < StuExLat; i++) begin
+    assign stu_exception_d[i+1] = stu_exception_q[i];
+    `FF(stu_exception_q[i], stu_exception_d[i], 1'b0, clk_i, rst_ni);
+  end
 
   operand_queues_stage #(
     .NrLanes   (NrLanes   ),
@@ -340,7 +346,7 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     .stu_operand_o                    (stu_operand_o                      ),
     .stu_operand_valid_o              (stu_operand_valid_o                ),
     .stu_operand_ready_i              (stu_operand_ready_i                ),
-    .stu_exception_i                  (stu_exception_q                    ),
+    .stu_exception_i                  (stu_exception                      ),
     // Address Generation Unit
     .sldu_addrgen_operand_o           (sldu_addrgen_operand_opqueues      ),
     .sldu_addrgen_operand_target_fu_o (sldu_addrgen_operand_target_fu_o   ),

--- a/hardware/src/lane/lane_sequencer.sv
+++ b/hardware/src/lane/lane_sequencer.sv
@@ -265,12 +265,9 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
       // Calculate the start element for Lane[i]. This will be forwarded to both opqueues
       // and operand requesters, with some light modification in the case of a vslide.
       // Regardless of the EW, the start element of Lane[i] is "vstart / NrLanes".
-      // The remainder is distributed from lane[0] on.
-      vfu_operation_d.vstart = pe_req.vstart / NrLanes; // High bits
-      // If lane_id_i < (vstart % NrLanes), this lane needs to execute one micro-operation less.
-      if (lane_id_i < pe_req.vstart[idx_width(NrLanes)-1:0]) begin : adjust_vstart_lane
-        vfu_operation_d.vstart += 1;
-      end : adjust_vstart_lane
+      // If vstart deos not divide NrLanes perfectly, some low-index lanes will send
+      // mock data to balance the payload.
+      vfu_operation_d.vstart = pe_req.vstart / NrLanes;
 
       // Mark the vector instruction as running
       vinsn_running_d[pe_req.id] = (vfu_operation_d.vfu != VFU_None) ? 1'b1 : 1'b0;

--- a/hardware/src/lane/lane_sequencer.sv
+++ b/hardware/src/lane/lane_sequencer.sv
@@ -473,7 +473,7 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
           operand_request[StA] = '{
             id      : pe_req.id,
             vs      : pe_req.vs1,
-            eew     : pe_req.eew_vs1,
+            eew     : pe_req.old_eew_vs1,
             conv    : pe_req.conversion_vs1,
             scale_vl: pe_req.scale_vl,
             vtype   : pe_req.vtype,

--- a/hardware/src/lane/lane_sequencer.sv
+++ b/hardware/src/lane/lane_sequencer.sv
@@ -489,7 +489,7 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
           // extra operand regardless of whether it is valid in this lane or not.
           // This is done to balance the data received by the store unit, which expects
           // L*64-bits packets only.
-          if (lane_id_i < pe_req.start_lane || lane_id_i > pe_req.end_lane) begin : tweak_vl_StA
+          if (lane_id_i > pe_req.end_lane) begin : tweak_vl_StA
             operand_request[StA].vl += 1;
           end : tweak_vl_StA
           operand_request_push[StA] = pe_req.use_vs1;

--- a/hardware/src/lane/lane_sequencer.sv
+++ b/hardware/src/lane/lane_sequencer.sv
@@ -539,6 +539,7 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
             eew      : pe_req.eew_vs2,
             conv     : pe_req.conversion_vs2,
             target_fu: ALU_SLDU,
+            is_slide : 1'b1,
             scale_vl : pe_req.scale_vl,
             vtype    : pe_req.vtype,
             vstart   : vfu_operation_d.vstart,
@@ -595,13 +596,14 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
 
           // This vector instruction uses masks
           operand_request[MaskM] = '{
-            id     : pe_req.id,
-            vs     : VMASK,
-            eew    : pe_req.vtype.vsew,
-            vtype  : pe_req.vtype,
-            vstart : vfu_operation_d.vstart,
-            hazard : pe_req.hazard_vm | pe_req.hazard_vd,
-            default: '0
+            id      : pe_req.id,
+            vs      : VMASK,
+            eew     : pe_req.vtype.vsew,
+            is_slide: 1'b1,
+            vtype   : pe_req.vtype,
+            vstart  : vfu_operation_d.vstart,
+            hazard  : pe_req.hazard_vm | pe_req.hazard_vd,
+            default : '0
           };
           operand_request_push[MaskM] = !pe_req.vm;
 

--- a/hardware/src/lane/lane_sequencer.sv
+++ b/hardware/src/lane/lane_sequencer.sv
@@ -21,7 +21,6 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
     input  logic                 [NrVInsn-1:0]            pe_vinsn_running_i,
     output logic                                          pe_req_ready_o,
     output pe_resp_t                                      pe_resp_o,
-    input  logic                                          need_mock_operand_i,
     // Interface with the operand requester
     output operand_request_cmd_t [NrOperandQueues-1:0]    operand_request_o,
     output logic                 [NrOperandQueues-1:0]    operand_request_valid_o,
@@ -55,21 +54,20 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
   pe_req_t pe_req;
   logic    pe_req_valid;
   logic    pe_req_ready;
-  logic    need_mock_operand;
 
   fall_through_register #(
-    .T(logic [$bits(pe_req_t):0])
+    .T(pe_req_t)
   ) i_pe_req_register (
-    .clk_i     (clk_i                          ),
-    .rst_ni    (rst_ni                         ),
-    .clr_i     (1'b0                           ),
-    .testmode_i(1'b0                           ),
-    .data_i    ({pe_req_i, need_mock_operand_i}),
-    .valid_i   (pe_req_valid_i_msk             ),
-    .ready_o   (pe_req_ready_o                 ),
-    .data_o    ({pe_req, need_mock_operand}    ),
-    .valid_o   (pe_req_valid                   ),
-    .ready_i   (pe_req_ready                   )
+    .clk_i     (clk_i             ),
+    .rst_ni    (rst_ni            ),
+    .clr_i     (1'b0              ),
+    .testmode_i(1'b0              ),
+    .data_i    (pe_req_i          ),
+    .valid_i   (pe_req_valid_i_msk),
+    .ready_o   (pe_req_ready_o    ),
+    .data_o    (pe_req            ),
+    .valid_o   (pe_req_valid      ),
+    .ready_i   (pe_req_ready      )
   );
 
   always_comb begin
@@ -259,14 +257,15 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
       };
       vfu_operation_valid_d = (vfu_operation_d.vfu != VFU_None) ? 1'b1 : 1'b0;
 
-      // Vector length calculation
+      // Vector length calculation for the
       vfu_operation_d.vl = pe_req.vl / NrLanes;
       // If lane_id_i < vl % NrLanes, this lane has to execute one extra micro-operation.
       if (lane_id_i < pe_req.vl[idx_width(NrLanes)-1:0]) vfu_operation_d.vl += 1;
 
-      // Vector start calculation
-      // TODO: check for LMUL = 4, 8
-      // TODO: check for SEW != 64
+      // Calculate the start element for Lane[i]. This will be forwarded to both opqueues
+      // and operand requesters, with some light modification in the case of a vslide.
+      // Regardless of the EW, the start element of Lane[i] is "vstart / NrLanes".
+      // The remainder is distributed from lane[0] on.
       vfu_operation_d.vstart = pe_req.vstart / NrLanes; // High bits
       // If lane_id_i < (vstart % NrLanes), this lane needs to execute one micro-operation less.
       if (lane_id_i < pe_req.vstart[idx_width(NrLanes)-1:0]) begin : adjust_vstart_lane
@@ -481,16 +480,16 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
             conv    : pe_req.conversion_vs1,
             scale_vl: pe_req.scale_vl,
             vtype   : pe_req.vtype,
-            // Since this request goes outside of the lane, we might need to request an
-            // extra operand regardless of whether it is valid in this lane or not.
-            vl      : pe_req.vl / NrLanes,
+            vl      : vfu_operation_d.vl,
             vstart  : vfu_operation_d.vstart,
             hazard  : pe_req.hazard_vs1 | pe_req.hazard_vd,
             default : '0
           };
-          // vl is not an integer multiple of NrLanes
-          // I.e., ( ( pe_req.vl / NrLanes * NrLanes ) == vl ) <=> ( ( vl % NrLanes ) != 0 )
-          if (need_mock_operand || (lane_id_i < pe_req.vl[idx_width(NrLanes)-1:0])) begin : tweak_vl_StA
+          // Since this request goes outside of the lane, we might need to request an
+          // extra operand regardless of whether it is valid in this lane or not.
+          // This is done to balance the data received by the store unit, which expects
+          // L*64-bits packets only.
+          if (lane_id_i < pe_req.start_lane || lane_id_i > pe_req.end_lane) begin : tweak_vl_StA
             operand_request[StA].vl += 1;
           end : tweak_vl_StA
           operand_request_push[StA] = pe_req.use_vs1;

--- a/hardware/src/lane/operand_queues_stage.sv
+++ b/hardware/src/lane/operand_queues_stage.sv
@@ -35,7 +35,7 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
     output elen_t                                    stu_operand_o,
     output logic                                     stu_operand_valid_o,
     input  logic                                     stu_operand_ready_i,
-    input  logic                                     stu_exception_i,
+    input  logic                                     stu_exception_flush_i,
     // Slide Unit/Address Generation unit
     output elen_t                                    sldu_addrgen_operand_o,
     output target_fu_e                               sldu_addrgen_operand_target_fu_o,
@@ -197,7 +197,7 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
   ) i_operand_queue_st_mask_a (
     .clk_i                    (clk_i                         ),
     .rst_ni                   (rst_ni                        ),
-    .flush_i                  (stu_exception_i               ),
+    .flush_i                  (stu_exception_flush_i         ),
     .lane_id_i                (lane_id_i                     ),
     .operand_queue_cmd_i      (operand_queue_cmd_i[StA]      ),
     .operand_queue_cmd_valid_i(operand_queue_cmd_valid_i[StA]),

--- a/hardware/src/lane/operand_queues_stage.sv
+++ b/hardware/src/lane/operand_queues_stage.sv
@@ -35,6 +35,7 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
     output elen_t                                    stu_operand_o,
     output logic                                     stu_operand_valid_o,
     input  logic                                     stu_operand_ready_i,
+    input  logic                                     stu_exception_i,
     // Slide Unit/Address Generation unit
     output elen_t                                    sldu_addrgen_operand_o,
     output target_fu_e                               sldu_addrgen_operand_target_fu_o,
@@ -64,6 +65,7 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
   ) i_operand_queue_alu_a (
     .clk_i                    (clk_i                          ),
     .rst_ni                   (rst_ni                         ),
+    .flush_i                  (1'b0                            ),
     .lane_id_i                (lane_id_i                      ),
     .operand_queue_cmd_i      (operand_queue_cmd_i[AluA]      ),
     .operand_queue_cmd_valid_i(operand_queue_cmd_valid_i[AluA]),
@@ -90,6 +92,7 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
   ) i_operand_queue_alu_b (
     .clk_i                    (clk_i                          ),
     .rst_ni                   (rst_ni                         ),
+    .flush_i                  (1'b0                            ),
     .lane_id_i                (lane_id_i                      ),
     .operand_queue_cmd_i      (operand_queue_cmd_i[AluB]      ),
     .operand_queue_cmd_valid_i(operand_queue_cmd_valid_i[AluB]),
@@ -118,6 +121,7 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
   ) i_operand_queue_mfpu_a (
     .clk_i                    (clk_i                             ),
     .rst_ni                   (rst_ni                            ),
+    .flush_i                  (1'b0                            ),
     .lane_id_i                (lane_id_i                         ),
     .operand_queue_cmd_i      (operand_queue_cmd_i[MulFPUA]      ),
     .operand_queue_cmd_valid_i(operand_queue_cmd_valid_i[MulFPUA]),
@@ -142,6 +146,7 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
   ) i_operand_queue_mfpu_b (
     .clk_i                    (clk_i                             ),
     .rst_ni                   (rst_ni                            ),
+    .flush_i                  (1'b0                            ),
     .lane_id_i                (lane_id_i                         ),
     .operand_queue_cmd_i      (operand_queue_cmd_i[MulFPUB]      ),
     .operand_queue_cmd_valid_i(operand_queue_cmd_valid_i[MulFPUB]),
@@ -166,6 +171,7 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
   ) i_operand_queue_mfpu_c (
     .clk_i                    (clk_i                             ),
     .rst_ni                   (rst_ni                            ),
+    .flush_i                  (1'b0                            ),
     .lane_id_i                (lane_id_i                         ),
     .operand_queue_cmd_i      (operand_queue_cmd_i[MulFPUC]      ),
     .operand_queue_cmd_valid_i(operand_queue_cmd_valid_i[MulFPUC]),
@@ -191,6 +197,7 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
   ) i_operand_queue_st_mask_a (
     .clk_i                    (clk_i                         ),
     .rst_ni                   (rst_ni                        ),
+    .flush_i                  (stu_exception_i               ),
     .lane_id_i                (lane_id_i                     ),
     .operand_queue_cmd_i      (operand_queue_cmd_i[StA]      ),
     .operand_queue_cmd_valid_i(operand_queue_cmd_valid_i[StA]),
@@ -216,6 +223,7 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
   ) i_operand_queue_slide_addrgen_a (
     .clk_i                    (clk_i                                         ),
     .rst_ni                   (rst_ni                                        ),
+    .flush_i                  (1'b0                                          ),
     .lane_id_i                (lane_id_i                                     ),
     .operand_queue_cmd_i      (operand_queue_cmd_i[SlideAddrGenA]            ),
     .operand_queue_cmd_valid_i(operand_queue_cmd_valid_i[SlideAddrGenA]      ),
@@ -244,6 +252,7 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
   ) i_operand_queue_mask_b (
     .clk_i                    (clk_i                           ),
     .rst_ni                   (rst_ni                          ),
+    .flush_i                  (1'b0                            ),
     .lane_id_i                (lane_id_i                       ),
     .operand_queue_cmd_i      (operand_queue_cmd_i[MaskB]      ),
     .operand_queue_cmd_valid_i(operand_queue_cmd_valid_i[MaskB]),
@@ -264,6 +273,7 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
   ) i_operand_queue_mask_m (
     .clk_i                    (clk_i                           ),
     .rst_ni                   (rst_ni                          ),
+    .flush_i                  (1'b0                            ),
     .lane_id_i                (lane_id_i                       ),
     .operand_queue_cmd_i      (operand_queue_cmd_i[MaskM]      ),
     .operand_queue_cmd_valid_i(operand_queue_cmd_valid_i[MaskM]),

--- a/hardware/src/vlsu/addrgen.sv
+++ b/hardware/src/vlsu/addrgen.sv
@@ -587,7 +587,7 @@ module addrgen import ara_pkg::*; import rvv_pkg::*; #(
 
     // The final address can be found similarly...
     if (num_bytes >= max_burst_bytes) begin
-        aligned_next_start_addr = aligned_addr(addr + max_burst_bytes, clog2_AxiStrobeWidth);
+        aligned_next_start_addr = aligned_addr(addr + max_burst_bytes, eff_axi_dw_log);
     end else begin
         aligned_next_start_addr = aligned_addr(addr + num_bytes - 1, eff_axi_dw_log) + eff_axi_dw;
     end
@@ -692,6 +692,8 @@ module addrgen import ara_pkg::*; import rvv_pkg::*; #(
           aligned_start_addr_d = aligned_addr(axi_addrgen_d.addr, clog2_AxiStrobeWidth);
           // Pre-calculate the next_2page_msb. This should not require much energy if the addr
           // has zeroes in the upper positions.
+          // We can use this also for the misaligned address calculation, as the next 2 page msb
+          // will be the same either way.
           next_2page_msb_d = aligned_start_addr_d[AxiAddrWidth-1:12] + 1;
           // The final address can be found similarly...
           set_end_addr (

--- a/hardware/src/vlsu/addrgen.sv
+++ b/hardware/src/vlsu/addrgen.sv
@@ -51,8 +51,8 @@ module addrgen import ara_pkg::*; import rvv_pkg::*; #(
     output ariane_pkg::exception_t         addrgen_exception_o,
     output logic                           addrgen_ack_o,
     output vlen_t                          addrgen_exception_vstart_o,
-    output logic                           addrgen_exception_load_o,
-    output logic                           addrgen_exception_store_o,
+    output logic                           addrgen_illegal_load_o,
+    output logic                           addrgen_illegal_store_o,
     // Interface with the load/store units
     output addrgen_axi_req_t               axi_addrgen_req_o,
     output logic                           axi_addrgen_req_valid_o,
@@ -226,8 +226,8 @@ module addrgen import ara_pkg::*; import rvv_pkg::*; #(
     addrgen_exception_o.valid = 1'b0;
     addrgen_exception_o.tval  = '0;
     addrgen_exception_o.cause = '0;
-    addrgen_exception_load_o  = 1'b0;
-    addrgen_exception_store_o = 1'b0;
+    addrgen_illegal_load_o  = 1'b0;
+    addrgen_illegal_store_o = 1'b0;
 
     // No valid words for the spill register
     idx_vaddr_valid_d       = 1'b0;
@@ -482,9 +482,10 @@ module addrgen import ara_pkg::*; import rvv_pkg::*; #(
       end : WAIT_LAST_TRANSLATION
     endcase // state_q
 
-    if ( addrgen_exception_o.valid & addrgen_ack_o ) begin
-      addrgen_exception_load_o  = is_load(pe_req_q.op);
-      addrgen_exception_store_o = !is_load(pe_req_q.op);
+    // Immediately kill the load/store if the instruction was illegal
+    if ( addrgen_exception_o.valid && addrgen_ack_o ) begin
+      addrgen_illegal_load_o  =  is_load(pe_req_q.op) && (addrgen_exception_o.cause == riscv::ILLEGAL_INSTR);
+      addrgen_illegal_store_o = !is_load(pe_req_q.op) && (addrgen_exception_o.cause == riscv::ILLEGAL_INSTR);
     end
   end : addr_generation
 

--- a/hardware/src/vlsu/addrgen.sv
+++ b/hardware/src/vlsu/addrgen.sv
@@ -820,10 +820,11 @@ module addrgen import ara_pkg::*; import rvv_pkg::*; #(
 
                 // Send this request to the load/store units
                 axi_addrgen_queue = '{
-                  addr   : paddr,
-                  len    : burst_length - 1,
-                  size   : eff_axi_dw_log_q,
-                  is_load: axi_addrgen_q.is_load
+                  addr         : paddr,
+                  len          : burst_length - 1,
+                  size         : eff_axi_dw_log_q,
+                  is_load      : axi_addrgen_q.is_load,
+                  is_exception : 1'b0
                 };
                 axi_addrgen_queue_push = 1'b1;
 
@@ -888,10 +889,11 @@ module addrgen import ara_pkg::*; import rvv_pkg::*; #(
 
                 // Send this request to the load/store units
                 axi_addrgen_queue = '{
-                  addr   : paddr,
-                  size   : axi_addrgen_q.vew,
-                  len    : 0,
-                  is_load: axi_addrgen_q.is_load
+                  addr         : paddr,
+                  size         : axi_addrgen_q.vew,
+                  len          : 0,
+                  is_load      : axi_addrgen_q.is_load,
+                  is_exception : 1'b0
                 };
                 axi_addrgen_queue_push = 1'b1;
 
@@ -956,10 +958,11 @@ module addrgen import ara_pkg::*; import rvv_pkg::*; #(
 
                     // Send this request to the load/store units
                     axi_addrgen_queue = '{
-                      addr   : idx_final_paddr,
-                      size   : axi_addrgen_q.vew,
-                      len    : 0,
-                      is_load: axi_addrgen_q.is_load
+                      addr         : idx_final_paddr,
+                      size         : axi_addrgen_q.vew,
+                      len          : 0,
+                      is_load      : axi_addrgen_q.is_load,
+                      is_exception : 1'b0
                     };
                     axi_addrgen_queue_push = 1'b1;
 
@@ -984,6 +987,16 @@ module addrgen import ara_pkg::*; import rvv_pkg::*; #(
             if ( mmu_exception_i.valid ) begin : mmu_exception_valid
               // Sample the exception
               mmu_exception_d = mmu_exception_i;
+
+              // Send the exception to the load or store unit
+              axi_addrgen_queue = '{
+                addr         : paddr,
+                size         : axi_addrgen_q.vew,
+                len          : 0,
+                is_load      : axi_addrgen_q.is_load,
+                is_exception : 1'b1
+              };
+              axi_addrgen_queue_push = 1'b1;
 
               // Set vstart: vl minus how many elements we have left
               // NOTE: this added complexity only comes from the fact that the beat counting

--- a/hardware/src/vlsu/addrgen.sv
+++ b/hardware/src/vlsu/addrgen.sv
@@ -583,9 +583,7 @@ module addrgen import ara_pkg::*; import rvv_pkg::*; #(
       output axi_addr_t                                 aligned_next_start_addr
   );
 
-    // POSSIBLE BUG: given this is really the maximum number of bytes per burst,
-    //                this assumes the burst length is always the maximum possible, i.e., 256.
-    automatic int unsigned max_burst_bytes = addr + (256 << eff_axi_dw_log);
+    automatic int unsigned max_burst_bytes = 256 << eff_axi_dw_log;
 
     // The final address can be found similarly...
     if (num_bytes >= max_burst_bytes) begin

--- a/hardware/src/vlsu/vldu.sv
+++ b/hardware/src/vlsu/vldu.sv
@@ -269,7 +269,7 @@ module vldu import ara_pkg::*; import rvv_pkg::*; #(
         // How many bytes are valid in this VRF word
         automatic vlen_t vrf_valid_bytes   = (NrLanes * DataWidthB) - vrf_word_byte_pnt_q;
         // How many bytes are valid in this instruction
-        automatic vlen_t vinsn_valid_bytes = issue_cnt_bytes_q - vrf_word_byte_pnt_q;
+        automatic vlen_t vinsn_valid_bytes = issue_cnt_bytes_q - vrf_word_byte_cnt_q;
         // How many bytes are valid in this AXI word
         automatic vlen_t axi_valid_bytes   = upper_byte - lower_byte - axi_r_byte_pnt_q + 1;
 
@@ -329,7 +329,7 @@ module vldu import ara_pkg::*; import rvv_pkg::*; #(
       end : operands_valid
 
       // We have a word ready to be sent to the lanes
-      if (vrf_word_byte_pnt_d == (NrLanes * DataWidthB) || vrf_word_byte_pnt_d == issue_cnt_bytes_q) begin : vrf_word_ready
+      if (vrf_word_byte_pnt_d == (NrLanes * DataWidthB) || vrf_word_byte_cnt_d == issue_cnt_bytes_q) begin : vrf_word_ready
         // Increment result queue pointers and counters
         result_queue_cnt_d += 1;
         if (result_queue_write_pnt_q == ResultQueueDepth-1) begin : result_queue_write_pnt_overflow

--- a/hardware/src/vlsu/vldu.sv
+++ b/hardware/src/vlsu/vldu.sv
@@ -37,6 +37,7 @@ module vldu import ara_pkg::*; import rvv_pkg::*; #(
     input  addrgen_axi_req_t               axi_addrgen_req_i,
     input  logic                           axi_addrgen_req_valid_i,
     output logic                           axi_addrgen_req_ready_o,
+    input  logic                           addrgen_illegal_load_i,
     // Interface with the lanes
     output logic             [NrLanes-1:0] ldu_result_req_o,
     output vid_t             [NrLanes-1:0] ldu_result_id_o,
@@ -488,7 +489,7 @@ module vldu import ara_pkg::*; import rvv_pkg::*; #(
     /////////////////////////
 
     // Clear instruction queue in case of exceptions from addrgen
-    if ( vinsn_issue_valid && axi_addrgen_req_valid_i && axi_addrgen_req_i.is_exception ) begin : exception
+    if ( vinsn_issue_valid && ((axi_addrgen_req_valid_i && axi_addrgen_req_i.is_exception) || addrgen_illegal_load_i) ) begin : exception
       // Signal done to sequencer
       pe_resp_d.vinsn_done[vinsn_commit.id] = 1'b1;
 
@@ -496,7 +497,7 @@ module vldu import ara_pkg::*; import rvv_pkg::*; #(
       load_complete_o = 1'b1;
 
       // Ack the addrgen for this last faulty request
-      axi_addrgen_req_ready_o = 1'b1;
+      axi_addrgen_req_ready_o = axi_addrgen_req_valid_i;
       // Reset axi state
       axi_len_d               = '0;
       axi_r_byte_pnt_d        = '0;

--- a/hardware/src/vlsu/vldu.sv
+++ b/hardware/src/vlsu/vldu.sv
@@ -192,9 +192,24 @@ module vldu import ara_pkg::*; import rvv_pkg::*; #(
   logic [idx_width(AxiDataWidth/8):0]      axi_r_byte_pnt_d, axi_r_byte_pnt_q;
   // - A pointer to which byte in the full VRF word we are writing data into.
   logic [idx_width(DataWidth*NrLanes/8):0] vrf_word_byte_pnt_d, vrf_word_byte_pnt_q;
+  // - A pointer that indicates the start byte in the vrf word.
+  logic [$clog2(8*NrLanes)-1:0] vrf_word_start_byte;
+
+  // A counter that follows the vrf_word_byte_pnt pointer, but without the vstart information
+  // We can compare this counter witht the issue_cnt_bytes counter to find the last byte in
+  // our transaction
+  logic [idx_width(DataWidth*NrLanes/8):0] vrf_word_byte_cnt_d, vrf_word_byte_cnt_q;
+
+  // When vstart > 0, the very first payload written to the VRF contains less than
+  // (8 * NrLanes) bytes.
+  logic [$clog2(8*NrLanes):0] first_payload_byte_d, first_payload_byte_q;
+  logic [$clog2(8*NrLanes):0] vrf_eff_write_bytes;
+
+  // Counter to increase the VRF write address.
+  vlen_t seq_word_wr_offset_d, seq_word_wr_offset_q;
 
   localparam unsigned DataWidthB = DataWidth / 8;
-  
+
   always_comb begin: p_vldu
     // Maintain state
     vinsn_queue_d = vinsn_queue_q;
@@ -212,6 +227,10 @@ module vldu import ara_pkg::*; import rvv_pkg::*; #(
     result_queue_cnt_d       = result_queue_cnt_q;
 
     result_final_gnt_d = result_final_gnt_q;
+
+    seq_word_wr_offset_d = seq_word_wr_offset_q;
+    first_payload_byte_d = first_payload_byte_q;
+    vrf_word_byte_cnt_d  = vrf_word_byte_cnt_q;
 
     // Vector instructions currently running
     vinsn_running_d = vinsn_running_q & pe_vinsn_running_i;
@@ -242,13 +261,13 @@ module vldu import ara_pkg::*; import rvv_pkg::*; #(
         axi_addrgen_req_i.size, axi_addrgen_req_i.len, BURST_INCR, AxiDataWidth/8, axi_len_q);
       automatic shortint unsigned upper_byte = beat_upper_byte(axi_addrgen_req_i.addr,
         axi_addrgen_req_i.size, axi_addrgen_req_i.len, BURST_INCR, AxiDataWidth/8, axi_len_q);
-      
+
       // Is there a vector instruction ready to be issued?
       // Do we have the operands for it?
       if (vinsn_issue_valid && (vinsn_issue_q.vm || (|mask_valid_i))) begin : operands_valid
         // Account for the issued bytes
         // How many bytes are valid in this VRF word
-        automatic vlen_t vrf_valid_bytes   = (NrLanes * DataWidthB) - vrf_word_byte_pnt_q; 
+        automatic vlen_t vrf_valid_bytes   = (NrLanes * DataWidthB) - vrf_word_byte_pnt_q;
         // How many bytes are valid in this instruction
         automatic vlen_t vinsn_valid_bytes = issue_cnt_bytes_q - vrf_word_byte_pnt_q;
         // How many bytes are valid in this AXI word
@@ -261,32 +280,31 @@ module vldu import ara_pkg::*; import rvv_pkg::*; #(
         valid_bytes = ( valid_bytes       < axi_valid_bytes        ) ? valid_bytes       : axi_valid_bytes;
 
         // Bump R beat and VRF word pointers
-        axi_r_byte_pnt_d   = axi_r_byte_pnt_q + valid_bytes;
+        axi_r_byte_pnt_d    = axi_r_byte_pnt_q + valid_bytes;
         vrf_word_byte_pnt_d = vrf_word_byte_pnt_q + valid_bytes;
+        vrf_word_byte_cnt_d = vrf_word_byte_cnt_q + valid_bytes;
 
         // Copy data from the R channel into the result queue
         for (int unsigned axi_byte = 0; axi_byte < AxiDataWidth/8; axi_byte++) begin : axi_r_to_result_queue
           // Is this byte a valid byte in the R beat?
           if ( ( axi_byte >= ( lower_byte + axi_r_byte_pnt_q ) ) &&
-               ( axi_byte <= upper_byte ) 
+               ( axi_byte <= upper_byte )
               ) begin : is_axi_r_byte
             // Map axi_byte to the corresponding byte in the VRF word (sequential)
             automatic int unsigned vrf_seq_byte = axi_byte - lower_byte - axi_r_byte_pnt_q + vrf_word_byte_pnt_q;
+            // Follow the vrf_seq_byte, but without the vstart information
+            automatic int unsigned vrf_seq_byte_cnt = axi_byte - lower_byte - axi_r_byte_pnt_q + vrf_word_byte_cnt_q;
             // And then shuffle it
             automatic int unsigned vrf_byte = shuffle_index(vrf_seq_byte, NrLanes, vinsn_issue_q.vtype.vsew);
 
             // Is this byte a valid byte in the VRF word?
-            if (vrf_seq_byte < issue_cnt_bytes_q && vrf_seq_byte < (NrLanes * DataWidthB)) begin : is_vrf_byte
+            // We compare vrf_seq_byte_cnt since vrf_seq_byte contains also the vstart contribution, while the issue_cnt_bytes
+            // counter does not.
+            if (vrf_seq_byte_cnt < issue_cnt_bytes_q && vrf_seq_byte < (NrLanes * DataWidthB)) begin : is_vrf_byte
               // At which lane, and what is the byte offset in that lane, of the byte vrf_byte?
               automatic int unsigned vrf_offset = vrf_byte[2:0];
-              // Consider also vstart and make sure this index wraps around the number of lane
+              // Make sure this index wraps around the number of lane
               automatic int unsigned vrf_lane = (vrf_byte >> 3);
-              // Adjust lane selection w.r.t. vstart
-              vrf_lane += vinsn_issue_q.vstart[idx_width(NrLanes)-1:0];
-              if ( vrf_lane >= NrLanes ) begin : vstart_lane_adjust
-                vrf_lane -= NrLanes;
-              end : vstart_lane_adjust
-
 
               // Copy data and byte strobe
               result_queue_d[result_queue_write_pnt_q][vrf_lane].wdata[8*vrf_offset +: 8] =
@@ -298,30 +316,14 @@ module vldu import ara_pkg::*; import rvv_pkg::*; #(
         end : axi_r_to_result_queue
 
         for (int unsigned lane = 0; lane < NrLanes; lane++) begin : compute_vrf_addr
-          automatic vlen_t issue_cnt_elems;
-          // elements per lane (each lane processes num elements / NrLanes)
-          automatic vlen_t elem_left_per_lane;
-          // 64-bit aligned address
-          automatic vlen_t lane_word_offset;
-          // How many elements in the vector body
-          automatic vlen_t elem_body_count;
           // vstart value local ot the lane
-          automatic vlen_t vstart_lane;        
-          
-          // Compute VRF chunk address per lane
-          elem_body_count    = vinsn_issue_q.vl - vinsn_issue_q.vstart;
-          issue_cnt_elems    = issue_cnt_bytes_q >> unsigned'(vinsn_issue_q.vtype.vsew);
-          elem_left_per_lane = ( elem_body_count - issue_cnt_elems ) / NrLanes;
-          lane_word_offset   = elem_left_per_lane >> (unsigned'(EW64) - unsigned'(vinsn_issue_q.vtype.vsew));
-          
+          automatic vlen_t vstart_lane;
+
+          // vstart of the lanes that we are writing to in this cycle
           vstart_lane = vinsn_issue_q.vstart / NrLanes;
-          // If lane_id < (vstart % NrLanes), this lane needs to execute one micro-operation less.
-          if ( lane < vinsn_issue_q.vstart[idx_width(NrLanes)-1:0] ) begin : vstart_lane_adjust
-            vstart_lane += 1;
-          end : vstart_lane_adjust
 
           // Store in result queue
-          result_queue_d[result_queue_write_pnt_q][lane].addr = vaddr(vinsn_issue_q.vd, NrLanes) + lane_word_offset + vstart_lane;  
+          result_queue_d[result_queue_write_pnt_q][lane].addr = vaddr(vinsn_issue_q.vd, NrLanes) + (vstart_lane >> (EW64 - vinsn_issue_q.vtype.vsew)) + seq_word_wr_offset_q;
           result_queue_d[result_queue_write_pnt_q][lane].id   = vinsn_issue_q.id;
         end : compute_vrf_addr
       end : operands_valid
@@ -338,16 +340,25 @@ module vldu import ara_pkg::*; import rvv_pkg::*; #(
         end : result_queue_write_pnt_increment
 
         // Trigger the request signal
-        // TODO: check if triggering all lanes is actually necessary here
         result_queue_valid_d[result_queue_write_pnt_q] = {NrLanes{1'b1}};
+
+        // Increase the VRF-write sequential counter
+        seq_word_wr_offset_d = seq_word_wr_offset_q + 1;
 
         // Acknowledge the mask operands
         mask_ready_o = !vinsn_issue_q.vm;
 
         // Reset the pointer in the VRF word
         vrf_word_byte_pnt_d   = '0;
+        vrf_word_byte_cnt_d   = '0;
         // Account for the results that were issued
-        issue_cnt_bytes_d = issue_cnt_bytes_q - (NrLanes * DataWidthB);
+        if (seq_word_wr_offset_q) begin
+          vrf_eff_write_bytes = (NrLanes * DataWidthB);
+        end else begin
+          // First payload of the vector instruction
+          vrf_eff_write_bytes = first_payload_byte_q;
+        end
+        issue_cnt_bytes_d = issue_cnt_bytes_q - vrf_eff_write_bytes;
         if (issue_cnt_bytes_q < (NrLanes * DataWidthB)) begin : issue_cnt_bytes_overflow
           issue_cnt_bytes_d = '0;
         end : issue_cnt_bytes_overflow
@@ -385,9 +396,16 @@ module vldu import ara_pkg::*; import rvv_pkg::*; #(
         // Prepare for the next vector instruction
         if (vinsn_queue_d.issue_cnt != 0) begin : issue_cnt_bytes_update
           issue_cnt_bytes_d = (
-                                vinsn_queue_q.vinsn[vinsn_queue_d.issue_pnt].vl 
+                                vinsn_queue_q.vinsn[vinsn_queue_d.issue_pnt].vl
                                 - vinsn_queue_q.vinsn[vinsn_queue_d.issue_pnt].vstart
                               ) << unsigned'(vinsn_queue_q.vinsn[vinsn_queue_d.issue_pnt].vtype.vsew);
+          // Prepare the VRF start pointer
+          vrf_word_start_byte  = vinsn_issue_d.vstart[$clog2(8*NrLanes)-1:0] << vinsn_issue_d.vtype.vsew;
+          vrf_word_byte_pnt_d  = {1'b0, vrf_word_start_byte[$clog2(8*NrLanes)-1:0]};
+          vrf_word_byte_cnt_d  = '0;
+          seq_word_wr_offset_d = '0;
+          // The first payload byte width for this vload
+          first_payload_byte_d = (NrLanes * DataWidthB) - vrf_word_start_byte[$clog2(8*NrLanes)-1:0];
         end : issue_cnt_bytes_update
       end : vrf_results_finish
     end : axi_r_beat_read
@@ -467,7 +485,7 @@ module vldu import ara_pkg::*; import rvv_pkg::*; #(
     /////////////////////////
     //  Handle exceptions  //
     /////////////////////////
-    
+
     // Clear instruction queue in case of exceptions from addrgen
     if ( vinsn_issue_valid & addrgen_exception_valid_i ) begin : exception
       // Signal done to sequencer
@@ -510,6 +528,16 @@ module vldu import ara_pkg::*; import rvv_pkg::*; #(
         commit_cnt_bytes_d = (pe_req_i.vl - pe_req_i.vstart) << unsigned'(pe_req_i.vtype.vsew);
       end : commit_cnt_bytes_init
 
+      // New instruction with new vstart. Initialize the vrf byte ptr
+      if (vinsn_queue_d.issue_cnt == '0) begin
+        vrf_word_start_byte  = pe_req_i.vstart[$clog2(8*NrLanes)-1:0] << pe_req_i.vtype.vsew;
+        vrf_word_byte_pnt_d  = {1'b0, vrf_word_start_byte[$clog2(8*NrLanes)-1:0]};
+        vrf_word_byte_cnt_d  = '0;
+        seq_word_wr_offset_d = '0;
+        // The first payload byte width for this vload
+        first_payload_byte_d = (NrLanes * DataWidthB) - vrf_word_start_byte[$clog2(8*NrLanes)-1:0];
+      end
+
       // Bump pointers and counters of the vector instruction queue
       vinsn_queue_d.accept_pnt += 1;
       vinsn_queue_d.issue_cnt += 1;
@@ -519,23 +547,29 @@ module vldu import ara_pkg::*; import rvv_pkg::*; #(
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      vinsn_running_q     <= '0;
-      issue_cnt_bytes_q   <= '0;
-      commit_cnt_bytes_q  <= '0;
-      axi_len_q           <= '0;
-      axi_r_byte_pnt_q    <= '0;
-      vrf_word_byte_pnt_q <= '0;
-      pe_resp_o           <= '0;
-      result_final_gnt_q  <= '0;
+      vinsn_running_q      <= '0;
+      issue_cnt_bytes_q    <= '0;
+      commit_cnt_bytes_q   <= '0;
+      axi_len_q            <= '0;
+      axi_r_byte_pnt_q     <= '0;
+      vrf_word_byte_pnt_q  <= '0;
+      pe_resp_o            <= '0;
+      result_final_gnt_q   <= '0;
+      seq_word_wr_offset_q <= '0;
+      first_payload_byte_q <= '0;
+      vrf_word_byte_cnt_q  <= '0;
     end else begin
-      vinsn_running_q     <= vinsn_running_d;
-      issue_cnt_bytes_q   <= issue_cnt_bytes_d;
-      commit_cnt_bytes_q  <= commit_cnt_bytes_d;
-      axi_len_q           <= axi_len_d;
-      axi_r_byte_pnt_q    <= axi_r_byte_pnt_d;
-      vrf_word_byte_pnt_q <= vrf_word_byte_pnt_d;
-      pe_resp_o           <= pe_resp_d;
-      result_final_gnt_q  <= result_final_gnt_d;
+      vinsn_running_q      <= vinsn_running_d;
+      issue_cnt_bytes_q    <= issue_cnt_bytes_d;
+      commit_cnt_bytes_q   <= commit_cnt_bytes_d;
+      axi_len_q            <= axi_len_d;
+      axi_r_byte_pnt_q     <= axi_r_byte_pnt_d;
+      vrf_word_byte_pnt_q  <= vrf_word_byte_pnt_d;
+      pe_resp_o            <= pe_resp_d;
+      result_final_gnt_q   <= result_final_gnt_d;
+      seq_word_wr_offset_q <= seq_word_wr_offset_d;
+      first_payload_byte_q <= first_payload_byte_d;
+      vrf_word_byte_cnt_q  <= vrf_word_byte_cnt_d;
     end
   end
 

--- a/hardware/src/vlsu/vldu.sv
+++ b/hardware/src/vlsu/vldu.sv
@@ -359,7 +359,7 @@ module vldu import ara_pkg::*; import rvv_pkg::*; #(
           vrf_eff_write_bytes = first_payload_byte_q;
         end
         issue_cnt_bytes_d = issue_cnt_bytes_q - vrf_eff_write_bytes;
-        if (issue_cnt_bytes_q < (NrLanes * DataWidthB)) begin : issue_cnt_bytes_overflow
+        if (issue_cnt_bytes_q < vrf_eff_write_bytes) begin : issue_cnt_bytes_overflow
           issue_cnt_bytes_d = '0;
         end : issue_cnt_bytes_overflow
       end : vrf_word_ready

--- a/hardware/src/vlsu/vlsu.sv
+++ b/hardware/src/vlsu/vlsu.sv
@@ -35,7 +35,6 @@ module vlsu import ara_pkg::*; import rvv_pkg::*; #(
     output logic                    load_complete_o,
     output logic                    store_complete_o,
     output logic                    store_pending_o,
-    output logic                    stu_exception_o,
     // Interface with the sequencer
     input  pe_req_t                 pe_req_i,
     input  logic                    pe_req_valid_i,
@@ -50,6 +49,7 @@ module vlsu import ara_pkg::*; import rvv_pkg::*; #(
     input  elen_t     [NrLanes-1:0] stu_operand_i,
     input  logic      [NrLanes-1:0] stu_operand_valid_i,
     output logic      [NrLanes-1:0] stu_operand_ready_o,
+    output logic                    stu_exception_flush_o,
     // Address generation operands
     input  elen_t     [NrLanes-1:0] addrgen_operand_i,
     input  target_fu_e[NrLanes-1:0] addrgen_operand_target_fu_i,
@@ -60,7 +60,7 @@ module vlsu import ara_pkg::*; import rvv_pkg::*; #(
     input  logic      [NrLanes-1:0] mask_valid_i,
     output logic                    vldu_mask_ready_o,
     output logic                    vstu_mask_ready_o,
-    
+
     // CSR input
     input  logic                    en_ld_st_translation_i,
 
@@ -159,8 +159,6 @@ module vlsu import ara_pkg::*; import rvv_pkg::*; #(
     .addrgen_ack_o              (addrgen_ack_o              ),
     .addrgen_exception_o        ( addrgen_exception_o       ),
     .addrgen_exception_vstart_o ( addrgen_exception_vstart_o ),
-    .addrgen_exception_load_o   ( addrgen_exception_load    ),
-    .addrgen_exception_store_o  ( addrgen_exception_store   ),
     // Interface with the lanes
     .addrgen_operand_i          (addrgen_operand_i          ),
     .addrgen_operand_target_fu_i(addrgen_operand_target_fu_i),
@@ -172,16 +170,16 @@ module vlsu import ara_pkg::*; import rvv_pkg::*; #(
     .ldu_axi_addrgen_req_ready_i(ldu_axi_addrgen_req_ready  ),
     .stu_axi_addrgen_req_ready_i(stu_axi_addrgen_req_ready  ),
 
-    // CSR input    
+    // CSR input
     .en_ld_st_translation_i,
     .mmu_misaligned_ex_o,
-    .mmu_req_o,        
-    .mmu_vaddr_o,      
-    .mmu_is_store_o,   
-    .mmu_dtlb_hit_i,   
-    .mmu_dtlb_ppn_i,   
+    .mmu_req_o,
+    .mmu_vaddr_o,
+    .mmu_is_store_o,
+    .mmu_dtlb_hit_i,
+    .mmu_dtlb_ppn_i,
     .mmu_valid_i,
-    .mmu_paddr_i,   
+    .mmu_paddr_i,
     .mmu_exception_i
   );
 
@@ -211,7 +209,6 @@ module vlsu import ara_pkg::*; import rvv_pkg::*; #(
     .pe_req_ready_o         (pe_req_ready_o[OffsetLoad]),
     .pe_resp_o              (pe_resp_o[OffsetLoad]     ),
     // Interface with the address generator
-    .addrgen_exception_valid_i ( addrgen_ack_o & addrgen_exception_o.valid ),
     .axi_addrgen_req_i      (axi_addrgen_req           ),
     .axi_addrgen_req_valid_i(axi_addrgen_req_valid     ),
     .axi_addrgen_req_ready_o(ldu_axi_addrgen_req_ready ),
@@ -260,7 +257,6 @@ module vlsu import ara_pkg::*; import rvv_pkg::*; #(
     .pe_req_ready_o         (pe_req_ready_o[OffsetStore]),
     .pe_resp_o              (pe_resp_o[OffsetStore]     ),
     // Interface with the address generator
-    .addrgen_exception_valid_i ( addrgen_ack_o & addrgen_exception_o.valid ),
     .axi_addrgen_req_i      (axi_addrgen_req            ),
     .axi_addrgen_req_valid_i(axi_addrgen_req_valid      ),
     .axi_addrgen_req_ready_o(stu_axi_addrgen_req_ready  ),
@@ -271,7 +267,8 @@ module vlsu import ara_pkg::*; import rvv_pkg::*; #(
     // Interface with the lanes
     .stu_operand_i          (stu_operand_i              ),
     .stu_operand_valid_i    (stu_operand_valid_i        ),
-    .stu_operand_ready_o    (stu_operand_ready_o        )
+    .stu_operand_ready_o    (stu_operand_ready_o        ),
+    .stu_exception_flush_o  (stu_exception_flush_o      )
   );
 
   //////////////////

--- a/hardware/src/vlsu/vlsu.sv
+++ b/hardware/src/vlsu/vlsu.sv
@@ -90,10 +90,8 @@ module vlsu import ara_pkg::*; import rvv_pkg::*; #(
   );
 
   logic load_complete, store_complete;
-  logic addrgen_exception_load, addrgen_exception_store;
-  assign load_complete_o  = load_complete  | addrgen_exception_load;
-  assign store_complete_o = store_complete | addrgen_exception_store;
-  assign stu_exception_o  = addrgen_exception_store;
+  assign load_complete_o  = load_complete;
+  assign store_complete_o = store_complete;
 
   ///////////////////
   //  Definitions  //

--- a/hardware/src/vlsu/vlsu.sv
+++ b/hardware/src/vlsu/vlsu.sv
@@ -90,6 +90,7 @@ module vlsu import ara_pkg::*; import rvv_pkg::*; #(
   );
 
   logic load_complete, store_complete;
+  logic addrgen_illegal_load, addrgen_illegal_store;
   assign load_complete_o  = load_complete;
   assign store_complete_o = store_complete;
 
@@ -159,6 +160,8 @@ module vlsu import ara_pkg::*; import rvv_pkg::*; #(
     .addrgen_ack_o              (addrgen_ack_o              ),
     .addrgen_exception_o        ( addrgen_exception_o       ),
     .addrgen_exception_vstart_o ( addrgen_exception_vstart_o ),
+    .addrgen_illegal_load_o     (addrgen_illegal_load      ),
+    .addrgen_illegal_store_o    (addrgen_illegal_store     ),
     // Interface with the lanes
     .addrgen_operand_i          (addrgen_operand_i          ),
     .addrgen_operand_target_fu_i(addrgen_operand_target_fu_i),
@@ -212,6 +215,7 @@ module vlsu import ara_pkg::*; import rvv_pkg::*; #(
     .axi_addrgen_req_i      (axi_addrgen_req           ),
     .axi_addrgen_req_valid_i(axi_addrgen_req_valid     ),
     .axi_addrgen_req_ready_o(ldu_axi_addrgen_req_ready ),
+    .addrgen_illegal_load_i (addrgen_illegal_load      ),
     // Interface with the Mask unit
     .mask_i                 (mask_i                    ),
     .mask_valid_i           (mask_valid_i              ),
@@ -260,6 +264,7 @@ module vlsu import ara_pkg::*; import rvv_pkg::*; #(
     .axi_addrgen_req_i      (axi_addrgen_req            ),
     .axi_addrgen_req_valid_i(axi_addrgen_req_valid      ),
     .axi_addrgen_req_ready_o(stu_axi_addrgen_req_ready  ),
+    .addrgen_illegal_store_i(addrgen_illegal_store      ),
     // Interface with the Mask unit
     .mask_i                 (mask_i                     ),
     .mask_valid_i           (mask_valid_i               ),

--- a/hardware/src/vlsu/vstu.sv
+++ b/hardware/src/vlsu/vstu.sv
@@ -301,7 +301,7 @@ module vstu import ara_pkg::*; import rvv_pkg::*; #(
             // Follow the vrf_seq_byte, but without the vstart information
             vrf_seq_byte_cnt = axi_byte - lower_byte + vrf_cnt_q;
             // And then shuffle it
-            vrf_byte     = shuffle_index(vrf_seq_byte, NrLanes, vinsn_issue_q.eew_vs1);
+            vrf_byte     = shuffle_index(vrf_seq_byte, NrLanes, vinsn_issue_q.old_eew_vs1);
 
             // Is this byte a valid byte in the VRF word?
             if (vrf_seq_byte_cnt < issue_cnt_bytes_q) begin
@@ -349,7 +349,7 @@ module vstu import ara_pkg::*; import rvv_pkg::*; #(
             vrf_eff_write_bytes = (NrLanes * DataWidthB);
           end
           issue_cnt_bytes_d = issue_cnt_bytes_q - vrf_eff_write_bytes;
-          if (issue_cnt_bytes_q < (NrLanes * DataWidthB)) begin : issue_cnt_bytes_overflow
+          if (issue_cnt_bytes_q < vrf_eff_write_bytes) begin : issue_cnt_bytes_overflow
             issue_cnt_bytes_d = '0;
           end : issue_cnt_bytes_overflow
         end : vrf_word_done

--- a/hardware/src/vlsu/vstu.sv
+++ b/hardware/src/vlsu/vstu.sv
@@ -71,8 +71,8 @@ module vstu import ara_pkg::*; import rvv_pkg::*; #(
   ///////////////////////
 
   elen_t [NrLanes-1:0] stu_operand;
-  logic  [NrLanes-1:0] stu_operand_valid_lanes;
-  logic                stu_operand_ready;
+  logic  [NrLanes-1:0] stu_operand_valid;
+  logic  [NrLanes-1:0] stu_operand_ready;
 
   for (genvar lane = 0; lane < NrLanes; lane++) begin: gen_regs
     fall_through_register #(
@@ -86,8 +86,8 @@ module vstu import ara_pkg::*; import rvv_pkg::*; #(
       .valid_i   (stu_operand_valid_i[lane]),
       .ready_o   (stu_operand_ready_o[lane]),
       .data_o    (stu_operand[lane]        ),
-      .valid_o   (stu_operand_valid_lanes[lane]  ),
-      .ready_i   (stu_operand_ready        )
+      .valid_o   (stu_operand_valid[lane]  ),
+      .ready_i   (stu_operand_ready[lane]  )
     );
   end: gen_regs
 
@@ -158,11 +158,12 @@ module vstu import ara_pkg::*; import rvv_pkg::*; #(
 
   // NOTE: these are out here only for debug visibility, they could go in p_vldu as automatic variables
   int unsigned vrf_seq_byte;
+  int unsigned vrf_seq_byte_cnt;
   int unsigned vrf_byte ;
   vlen_t vrf_valid_bytes ;
   vlen_t vinsn_valid_bytes;
   vlen_t axi_valid_bytes   ;
-  logic [idx_width(DataWidth*NrLanes/8):0] valid_bytes;      
+  logic [idx_width(DataWidth*NrLanes/8):0] valid_bytes;
 
 
   // Vector instructions currently running
@@ -183,9 +184,26 @@ module vstu import ara_pkg::*; import rvv_pkg::*; #(
   // - A pointer to which byte in the full VRF word we are reading data from.
   logic [idx_width(DataWidth*NrLanes/8):0] vrf_pnt_d, vrf_pnt_q;
 
+  // When vstart > 0, the very first payload written to the VRF contains less than
+  // (8 * NrLanes) bytes.
+  logic [$clog2(8*NrLanes):0] first_payload_byte_d, first_payload_byte_q;
+  logic [$clog2(8*NrLanes):0] vrf_eff_write_bytes;
+
+  // A counter that follows the vrf_word_byte_pnt pointer, but without the vstart information
+  // We can compare this counter witht the issue_cnt_bytes counter to find the last byte in
+  // our transaction
+  logic [idx_width(DataWidth*NrLanes/8):0] vrf_cnt_d, vrf_cnt_q;
+  // - A pointer that indicates the start byte in the vrf word.
+  logic [$clog2(8*NrLanes)-1:0] vrf_word_start_byte;
+  // First payload from the lanes? If yes, it can be offset by vstart.
+  logic first_lane_payload_d, first_lane_payload_q;
+  // The index of the first lane with valid data when vstart != 0
+  logic [$clog2(NrLanes)-1:0] first_valid_lane_idx_d, first_valid_lane_idx_q;
+
   always_comb begin: p_vstu
     // NOTE: these are out here only for debug visibility, they could go in p_vldu as automatic variables
     vrf_seq_byte = '0;
+    vrf_seq_byte_cnt = '0;
     vrf_byte  = '0;
     vrf_valid_bytes  = '0;
     vinsn_valid_bytes = '0;
@@ -211,6 +229,13 @@ module vstu import ara_pkg::*; import rvv_pkg::*; #(
     stu_operand_ready       = 1'b0;
     mask_ready_o            = 1'b0;
     store_complete_o        = 1'b0;
+    vrf_word_start_byte     = '0;
+
+    first_payload_byte_d = first_payload_byte_q;
+
+    vrf_cnt_d = vrf_cnt_q;
+    first_lane_payload_d = first_lane_payload_q;
+    first_valid_lane_idx_d = first_valid_lane_idx_q;
 
     // Inform the main sequencer if we are idle
     pe_req_ready_o = !vinsn_queue_full;
@@ -233,12 +258,11 @@ module vstu import ara_pkg::*; import rvv_pkg::*; #(
         axi_addrgen_req_i.size, axi_addrgen_req_i.len, BURST_INCR, AxiDataWidth/8, axi_len_q);
 
       // For non-zero vstart values, the last operand read is not going to involve all the lanes
-      automatic logic [NrLanes-1:0] stu_operand_valid;
       automatic logic [NrLanes-1:0] mask_valid;
 
       // How many bytes are we committing?
-      // automatic logic [idx_width(DataWidth*NrLanes/8):0] valid_bytes;      
-      
+      // automatic logic [idx_width(DataWidth*NrLanes/8):0] valid_bytes;
+
       // Account for the issued bytes
       // How many bytes are valid in this VRF word
       vrf_valid_bytes   = (NrLanes * DataWidthB) - vrf_pnt_q;
@@ -250,19 +274,6 @@ module vstu import ara_pkg::*; import rvv_pkg::*; #(
       valid_bytes = ( issue_cnt_bytes_q < (NrLanes * DataWidthB) ) ? vinsn_valid_bytes : vrf_valid_bytes;
       valid_bytes = ( valid_bytes < axi_valid_bytes              ) ? valid_bytes       : axi_valid_bytes;
 
-      // Adjust valid signals to the next block "operands_ready"
-      stu_operand_valid = stu_operand_valid_lanes;
-      for ( int unsigned lane = 0; lane < NrLanes; lane++ ) begin : adjust_operand_valid
-        // - We are left with less byte than the maximim to issue, 
-        //    this means that at least one lane is not going to push us any operand anymore
-        // - For the lanes which index % NrLanes != 0
-        if ( ( issue_cnt_bytes_q < (NrLanes * DataWidthB) )
-              & ( lane < vinsn_issue_q.vstart[idx_width(NrLanes)-1:0] )
-              ) begin : vstart_lane_adjust
-          stu_operand_valid[lane] |= 1'b1;
-        end : vstart_lane_adjust
-      end : adjust_operand_valid
-    
       // TODO: apply the same vstart logic also to mask_valid_i
       // For now, assume (vstart % NrLanes == 0)
       mask_valid = mask_valid_i;
@@ -270,6 +281,7 @@ module vstu import ara_pkg::*; import rvv_pkg::*; #(
       // Wait for all expected operands from the lanes
       if ( &stu_operand_valid && (vinsn_issue_q.vm || (|mask_valid_i) ) ) begin : operands_ready
         vrf_pnt_d = vrf_pnt_q + valid_bytes;
+        vrf_cnt_d = vrf_cnt_q + valid_bytes;
 
         // Copy data from the operands into the W channel
         for (int unsigned axi_byte = 0; axi_byte < AxiDataWidth/8; axi_byte++) begin : stu_operand_to_axi_w
@@ -277,22 +289,17 @@ module vstu import ara_pkg::*; import rvv_pkg::*; #(
           if (axi_byte >= lower_byte && axi_byte <= upper_byte) begin
             // Map axy_byte to the corresponding byte in the VRF word (sequential)
             vrf_seq_byte = axi_byte - lower_byte + vrf_pnt_q;
+            // Follow the vrf_seq_byte, but without the vstart information
+            vrf_seq_byte_cnt = axi_byte - lower_byte + vrf_cnt_q;
             // And then shuffle it
             vrf_byte     = shuffle_index(vrf_seq_byte, NrLanes, vinsn_issue_q.eew_vs1);
 
             // Is this byte a valid byte in the VRF word?
-            if (vrf_seq_byte < issue_cnt_bytes_q) begin
+            if (vrf_seq_byte_cnt < issue_cnt_bytes_q) begin
               // At which lane, and what is the byte offset in that lane, of the byte vrf_byte?
               automatic int unsigned vrf_offset = vrf_byte[2:0];
-
-              // Consider also vstart and make sure this index wraps around the number of lane
               // automatic logic [$clog2(NrLanes)-1:0] vrf_lane = (vrf_byte >> 3) + vinsn_issue_q.vstart[idx_width(NrLanes)-1:0];
               automatic int unsigned vrf_lane = (vrf_byte >> 3);
-              // Adjust lane selection w.r.t. vstart
-              vrf_lane += vinsn_issue_q.vstart[idx_width(NrLanes)-1:0];
-              if ( vrf_lane >= NrLanes ) begin : vstart_lane_adjust
-                vrf_lane -= NrLanes;
-              end : vstart_lane_adjust
 
               // Copy data
               axi_w_o.data[8*axi_byte +: 8] = stu_operand[vrf_lane][8*vrf_offset +: 8];
@@ -318,12 +325,27 @@ module vstu import ara_pkg::*; import rvv_pkg::*; #(
         if (vrf_pnt_d == NrLanes*8 || vrf_pnt_d == issue_cnt_bytes_q) begin : vrf_word_done
           // Reset the pointer in the VRF word
           vrf_pnt_d         = '0;
+          vrf_cnt_d         = '0;
+          // Next payloads will not be affected by vstart anymore
+          first_lane_payload_d = 1'b0;
           // Acknowledge the operands with the lanes
-          stu_operand_ready = '1;
+          for (int unsigned lane = 0; lane < NrLanes; lane++) begin
+            if (lane >= first_valid_lane_idx_q) begin
+              stu_operand_ready[lane] = 1'b1;
+            end
+          end
+          // From now on, the valid elements come from lane 0 regardless of vstart
+          first_valid_lane_idx_d = '0;
           // Acknowledge the mask operand
           mask_ready_o      = !vinsn_issue_q.vm;
           // Account for the results that were issued
-          issue_cnt_bytes_d       = issue_cnt_bytes_q - (NrLanes * DataWidthB);
+          if (first_lane_payload_q) begin
+            vrf_eff_write_bytes = first_payload_byte_q;
+          end else begin
+            // First payload of the vector instruction
+            vrf_eff_write_bytes = (NrLanes * DataWidthB);
+          end
+          issue_cnt_bytes_d = issue_cnt_bytes_q - vrf_eff_write_bytes;
           if (issue_cnt_bytes_q < (NrLanes * DataWidthB)) begin : issue_cnt_bytes_overflow
             issue_cnt_bytes_d = '0;
           end : issue_cnt_bytes_overflow
@@ -344,9 +366,20 @@ module vstu import ara_pkg::*; import rvv_pkg::*; #(
 
       // Load issue_cnt_bytes_d for next instruction (if any)
       if (vinsn_queue_d.issue_cnt != 0) begin : issue_cnt_bytes_update
-        issue_cnt_bytes_d = ( vinsn_queue_q.vinsn[vinsn_queue_d.issue_pnt].vl - 
+        issue_cnt_bytes_d = ( vinsn_queue_q.vinsn[vinsn_queue_d.issue_pnt].vl -
                         vinsn_queue_q.vinsn[vinsn_queue_d.issue_pnt].vstart
                       ) << unsigned'(vinsn_queue_q.vinsn[vinsn_queue_d.issue_pnt].vtype.vsew);
+        // Prepare the VRF start pointer
+        vrf_word_start_byte = pe_req_i.vstart[$clog2(8*NrLanes)-1:0] << pe_req_i.vtype.vsew;
+        vrf_pnt_d           = {1'b0, vrf_word_start_byte[$clog2(8*NrLanes)-1:0]};
+        vrf_cnt_d           = '0;
+        // The first payload byte width for this vload
+        first_payload_byte_d = (NrLanes * DataWidthB) - vrf_word_start_byte[$clog2(8*NrLanes)-1:0];
+        // The next payload will be the first one for this store
+        first_lane_payload_d = 1'b1;
+        // For the first payload, we need to handshake only the correct incoming operands.
+        // The lanes from the start lane to the last one have to be handshaked.
+        first_valid_lane_idx_d = vrf_word_start_byte[$clog2(8*NrLanes)-1:$clog2(8)];
       end : issue_cnt_bytes_update
     end : axi_w_beat_finish
 
@@ -393,7 +426,7 @@ module vstu import ara_pkg::*; import rvv_pkg::*; #(
       else begin : issue_pnt_increment
         vinsn_queue_d.issue_pnt += 1;
       end : issue_pnt_increment
-      
+
       // Mark the vector instruction as being done
       // if (vinsn_queue_d.issue_pnt != vinsn_queue_d.commit_pnt) begin : instr_done
         // Signal done to sequencer
@@ -426,6 +459,20 @@ module vstu import ara_pkg::*; import rvv_pkg::*; #(
         issue_cnt_bytes_d = (pe_req_i.vl - pe_req_i.vstart) << unsigned'(pe_req_i.vtype.vsew);
       end : issue_cnt_bytes_init
 
+      // Setup pointers and counters with vstart
+      if (vinsn_queue_d.issue_cnt == '0) begin
+        vrf_word_start_byte = pe_req_i.vstart[$clog2(8*NrLanes)-1:0] << pe_req_i.vtype.vsew;
+        vrf_pnt_d           = {1'b0, vrf_word_start_byte[$clog2(8*NrLanes)-1:0]};
+        vrf_cnt_d           = '0;
+        // The first payload byte width for this vload
+        first_payload_byte_d = (NrLanes * DataWidthB) - vrf_word_start_byte[$clog2(8*NrLanes)-1:0];
+        // The next payload will be the first one for this store
+        first_lane_payload_d = 1'b1;
+        // For the first payload, we need to handshake only the correct incoming operands.
+        // The lanes from the start lane to the last one have to be handshaked.
+        first_valid_lane_idx_d = vrf_word_start_byte[$clog2(8*NrLanes)-1:$clog2(8)];
+      end
+
       // Bump pointers and counters of the vector instruction queue
       vinsn_queue_d.accept_pnt += 1;
       vinsn_queue_d.issue_cnt += 1;
@@ -435,21 +482,33 @@ module vstu import ara_pkg::*; import rvv_pkg::*; #(
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      vinsn_running_q <= '0;
-      issue_cnt_bytes_q     <= '0;
+      vinsn_running_q   <= '0;
+      issue_cnt_bytes_q <= '0;
 
-      axi_len_q     <= '0;
+      axi_len_q <= '0;
       vrf_pnt_q <= '0;
 
       pe_resp_o <= '0;
-    end else begin
-      vinsn_running_q <= vinsn_running_d;
-      issue_cnt_bytes_q     <= issue_cnt_bytes_d;
 
-      axi_len_q     <= axi_len_d;
+      first_payload_byte_q <= '0;
+      first_lane_payload_q <= '0;
+
+      vrf_cnt_q <= '0;
+      first_valid_lane_idx_q <= '0;
+    end else begin
+      vinsn_running_q   <= vinsn_running_d;
+      issue_cnt_bytes_q <= issue_cnt_bytes_d;
+
+      axi_len_q <= axi_len_d;
       vrf_pnt_q <= vrf_pnt_d;
 
       pe_resp_o <= pe_resp_d;
+
+      first_payload_byte_q <= first_payload_byte_d;
+      first_lane_payload_q <= first_lane_payload_d;
+
+      vrf_cnt_q <= vrf_cnt_d;
+      first_valid_lane_idx_q <= first_valid_lane_idx_d;
     end
   end
 

--- a/hardware/src/vlsu/vstu.sv
+++ b/hardware/src/vlsu/vstu.sv
@@ -48,6 +48,7 @@ module vstu import ara_pkg::*; import rvv_pkg::*; #(
     input  addrgen_axi_req_t               axi_addrgen_req_i,
     input  logic                           axi_addrgen_req_valid_i,
     output logic                           axi_addrgen_req_ready_o,
+    input  logic                           addrgen_illegal_store_i,
     // Interface with the lanes
     input  elen_t            [NrLanes-1:0] stu_operand_i,
     input  logic             [NrLanes-1:0] stu_operand_valid_i,
@@ -421,7 +422,7 @@ module vstu import ara_pkg::*; import rvv_pkg::*; #(
     ////////////////////////
 
     // Clear instruction from queue and data in case of exceptions from addrgen
-    if ( vinsn_issue_valid && axi_addrgen_req_valid_i && axi_addrgen_req_i.is_exception ) begin : exception
+    if ( vinsn_issue_valid && ((axi_addrgen_req_valid_i && axi_addrgen_req_i.is_exception) || addrgen_illegal_store_i) ) begin : exception
       // Bump issue counters and pointers of the vector instruction queue
       vinsn_queue_d.issue_cnt -= 1;
       issue_cnt_bytes_d = '0;
@@ -437,7 +438,7 @@ module vstu import ara_pkg::*; import rvv_pkg::*; #(
       stu_op_flush_cnt_en   = 1'b1;
 
       // Ack the addrgen for this last faulty request
-      axi_addrgen_req_ready_o = 1'b1;
+      axi_addrgen_req_ready_o = axi_addrgen_req_valid_i;
       // Reset AXI pointers
       axi_len_d = '0;
 


### PR DESCRIPTION
- [x] Store-exceptions from STUB

The store unit now gets balanced payloads from all the lanes. If `vstart > 0` and `vstart % NrLanes = k`, and `k > 0`, the lanes with index `L < k` will send anyway their 64-bit payloads, even if it does not contain valid elements. The store unit only uses the valid elements from the `NrLanes*64-bit` payload and gives balanced ready signals to all the lanes at the same time.